### PR TITLE
Add pool recycling to eliminate closed connection issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Then, you can use the `FlaskPooledClusterRpcProxy` singleton just as you would n
 * `NAMEKO_MAX_CONNECTIONS (int, default=8)` - the max number of connections to the Nameko cluster to create before raises an error
 * `NAMEKO_CONNECT_ON_METHOD_CALL (bool, default=True)` - whether connections to services should be loaded when the service is accessed (False) or when a method is called on a service (True)
 * `NAMEKO_RPC_TIMEOUT` (int, default=None) - the default timeout before raising an error when trying to call a service RPC method
+* `NAMEKO_POOL_RECYCLE` (int, default=None) - if specified, connections that are older than this interval, specified in seconds, will be automatically recycled on checkout. This setting is useful for environments where connections are happening through a proxy like HAProxy which automatically closes connections after a specified interval.
 
 ### Proxies
 

--- a/flask_nameko/connection_pool.py
+++ b/flask_nameko/connection_pool.py
@@ -1,9 +1,21 @@
+from datetime import datetime, timedelta
 from Queue import Queue, Empty
 from threading import Lock
 from .errors import ClientUnavailableError
 
+class Connection(object):
+    def __init__(self, connection):
+        self.connection = connection
+        self._created_at = datetime.now()
+
+    def is_stale(self, recycle_interval):
+        return (datetime.now() - self._created_at) > recycle_interval
+
+    def __getattr__(self, attr):
+        return getattr(self.connection, attr)
+
 class ConnectionPool(object):
-    def __init__(self, get_connection, initial_connections=2, max_connections=8):
+    def __init__(self, get_connection, initial_connections=2, max_connections=8, recycle=None):
         """
         Create a new pool
         :param func get_connection: The function that returns a connection
@@ -18,6 +30,7 @@ class ConnectionPool(object):
         self._queue = Queue()
         self._current_connections = 0
         self._max_connections = max_connections
+        self._recycle = timedelta(seconds=recycle) if recycle else False
         self._lock = Lock()
 
         for x in range(initial_connections):
@@ -25,21 +38,22 @@ class ConnectionPool(object):
             self._queue.put(connection)
 
     def _make_connection(self):
-        ret = self._get_connection()
+        ret = Connection(self._get_connection())
         self._current_connections += 1
         return ret
 
-    def get_connection(self, initial_timeout=0.05, next_timeout=1):
-        """
-        Wait until a connection instance is available
-        :param float initial_timeout:
-          how long to wait initially for an existing connection to complete
-        :param float next_timeout:
-          if the pool could not obtain a connection during the initial timeout,
-          and we have allocated the maximum available number of connections, wait
-          this long until we can retrieve another one
-        :return: A connection object
-        """
+    def _delete_connection(self, connection):
+        del connection
+        self._current_connections -= 1
+
+    def _recycle_connection(self, connection):
+        self._lock.acquire()
+        self._delete_connection(connection)
+        connection = self._make_connection()
+        self._lock.release()
+        return connection
+
+    def _get_connection_from_queue(self, initial_timeout, next_timeout):
         try:
             return self._queue.get(True, initial_timeout)
         except Empty:
@@ -56,6 +70,24 @@ class ConnectionPool(object):
                     raise ex
             finally:
                 self._lock.release()
+
+    def get_connection(self, initial_timeout=0.05, next_timeout=1):
+        """
+        Wait until a connection instance is available
+        :param float initial_timeout:
+          how long to wait initially for an existing connection to complete
+        :param float next_timeout:
+          if the pool could not obtain a connection during the initial timeout,
+          and we have allocated the maximum available number of connections, wait
+          this long until we can retrieve another one
+        :return: A connection object
+        """
+        connection = self._get_connection_from_queue(initial_timeout, next_timeout)
+
+        if self._recycle and connection.is_stale(self._recycle):
+            connection = self._recycle_connection(connection)
+
+        return connection
 
     def release_connection(self, cb):
         """

--- a/flask_nameko/proxies.py
+++ b/flask_nameko/proxies.py
@@ -24,7 +24,8 @@ class PooledClusterRpcProxy(object):
         self._pool = ConnectionPool(
             self._get_nameko_connection,
             initial_connections=config.get('INITIAL_CONNECTIONS', 2),
-            max_connections=config.get('MAX_CONNECTIONS', 8)
+            max_connections=config.get('MAX_CONNECTIONS', 8),
+            recycle=config.get('POOL_RECYCLE')
         )
 
     def _get_nameko_connection(self):

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pytest
-from mock import Mock
-from flask_nameko.connection_pool import ConnectionPool
+import eventlet
+from datetime import timedelta
+from mock import Mock, patch
+from flask_nameko.connection_pool import ConnectionPool, Connection
 from flask_nameko.errors import ClientUnavailableError
 
 @pytest.fixture
@@ -45,3 +47,33 @@ def test_max_connections_raises(get_connection):
 def test_creates_initial_connections(get_connection):
     pool = ConnectionPool(get_connection, initial_connections=2)
     assert get_connection.call_count == 2
+
+def test_connections_get_recycled(get_connection):
+    pool = ConnectionPool(
+        get_connection,
+        initial_connections=1,
+        max_connections=1,
+        recycle=3600
+    )
+
+    conn = pool.get_connection()
+    pool.release_connection(conn)
+    conn2 = pool.get_connection()
+    pool.release_connection(conn2)
+
+    assert conn == conn2
+
+    with patch.object(conn2, 'is_stale', return_value=True):
+        conn3 = pool.get_connection()
+
+    assert conn3 != conn
+    assert conn3 != conn2
+
+def test_connection_is_stale_for_stale_connection():
+    connection = Connection(None)
+    eventlet.sleep(2)
+    assert connection.is_stale(timedelta(seconds=1))
+
+def test_connection_is_not_stale_for_good_connection():
+    connection = Connection(None)
+    assert not connection.is_stale(timedelta(seconds=3600))

--- a/tests/test_flask_pooled_cluster_rpc_proxy.py
+++ b/tests/test_flask_pooled_cluster_rpc_proxy.py
@@ -5,6 +5,7 @@ from mock import Mock, patch, ANY, MagicMock
 from nameko.standalone.rpc import ClusterRpcProxy
 from flask import Flask, g
 from flask_nameko import FlaskPooledClusterRpcProxy
+from flask_nameko.connection_pool import ConnectionPool
 from flask_nameko.proxies import LazyServiceProxy
 from flask_nameko.errors import (
     ClientUnavailableError,
@@ -87,3 +88,8 @@ def test_timeout_is_passed_through_to_cluster(flask_app):
         FlaskPooledClusterRpcProxy(flask_app, connect_on_method_call=True)
         mock.assert_called_with(ANY, timeout=10)
 
+def test_pool_recycle_is_passed_through_to_cluster(flask_app):
+    flask_app.config.update(dict(NAMEKO_POOL_RECYCLE=3600))
+    with patch('flask_nameko.proxies.ConnectionPool', spec_set=ConnectionPool) as mock:
+        FlaskPooledClusterRpcProxy(flask_app)
+        mock.assert_called_with(ANY, initial_connections=ANY, max_connections=ANY, recycle=3600)


### PR DESCRIPTION
This PR addresses the `IOError: Socket closed` error that we've been seeing when systems idle for a long time and have their RabbitMQ connections closed remotely by HAProxy. To resolve this issue, we borrow the concept of "pool recycling" from sqlalchemy (and almost certainly lots of other places). With pool recycling enabled, connections older than the specified recycle interval will be automatically "recycled" on checkout by the connection pool. Since our HAProxy cluster automatically terminates connections that haven't been used and are older than 3 hours (10800 seconds) old, we'll set out pool recycle value to less than this: likely `3600`.
