### PR TITLE
Redefine context_data and worker_cls for ClusterRpcProxy + python3 support

### DIFF
--- a/flask_nameko/__init__.py
+++ b/flask_nameko/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
+from .errors import *
+from .proxies import FlaskPooledClusterRpcProxy
+
 __author__ = 'Jesse Pollak'
 __email__ = 'jesse@getclef.com'
 __version__ = '1.3.0'
-
-from errors import *
-from proxies import FlaskPooledClusterRpcProxy

--- a/flask_nameko/connection_pool.py
+++ b/flask_nameko/connection_pool.py
@@ -36,11 +36,11 @@ class ConnectionPool(object):
         self._get_connection = get_connection
         self._queue = Queue()
         self._current_connections = 0
-        self._max_connections = max_connections
-        self._recycle = timedelta(seconds=recycle) if recycle else False
+        self._max_connections = int(max_connections)
+        self._recycle = timedelta(seconds=int(recycle)) if recycle else False
         self._lock = Lock()
 
-        for x in range(initial_connections):
+        for x in range(int(initial_connections)):
             connection = self._make_connection()
             self._queue.put(connection)
 

--- a/flask_nameko/connection_pool.py
+++ b/flask_nameko/connection_pool.py
@@ -1,7 +1,13 @@
 from datetime import datetime, timedelta
-from Queue import Queue, Empty
 from threading import Lock
+
+try:
+    from Queue import Queue, Empty
+except ImportError:
+    from queue import Queue, Empty
+
 from .errors import ClientUnavailableError
+
 
 class Connection(object):
     def __init__(self, connection):
@@ -13,6 +19,7 @@ class Connection(object):
 
     def __getattr__(self, attr):
         return getattr(self.connection, attr)
+
 
 class ConnectionPool(object):
     def __init__(self, get_connection, initial_connections=2, max_connections=8, recycle=None):

--- a/flask_nameko/errors.py
+++ b/flask_nameko/errors.py
@@ -1,6 +1,14 @@
-class BadConfigurationError(Exception):
+class FlaskNamekoException(Exception):
     pass
-class ClientUnavailableError(Exception):
+
+
+class BadConfigurationError(FlaskNamekoException):
     pass
-class ClusterNotConfiguredError(Exception):
+
+
+class ClientUnavailableError(FlaskNamekoException):
+    pass
+
+
+class ClusterNotConfiguredError(FlaskNamekoException):
     pass

--- a/flask_nameko/proxies.py
+++ b/flask_nameko/proxies.py
@@ -15,7 +15,8 @@ class PooledClusterRpcProxy(object):
     _pool = None
     _config = None
 
-    def __init__(self, config=None):
+    def __init__(self, config=None, context_data=None):
+        self.context_data = context_data
         if config:
             self.configure(config)
 
@@ -34,7 +35,8 @@ class PooledClusterRpcProxy(object):
     def _get_nameko_connection(self):
         proxy = ClusterRpcProxy(
             self._config,
-            timeout=self._config.get('RPC_TIMEOUT', None)
+            timeout=self._config.get('RPC_TIMEOUT', None),
+            context_data=self.context_data
         )
         return proxy.start()
 
@@ -57,8 +59,8 @@ class LazyServiceProxy(object):
 
 
 class FlaskPooledClusterRpcProxy(PooledClusterRpcProxy):
-    def __init__(self, app=None, connect_on_method_call=True):
-        super().__init__()
+    def __init__(self, app=None, context_data=None, connect_on_method_call=True):
+        super().__init__(context_data=context_data)
         self._connect_on_method_call = connect_on_method_call
         if app:
             self.init_app(app)

--- a/flask_nameko/proxies.py
+++ b/flask_nameko/proxies.py
@@ -38,7 +38,7 @@ class PooledClusterRpcProxy(object):
     def _get_nameko_connection(self):
         proxy = ClusterRpcProxy(
             self._config,
-            timeout=self._config.get('RPC_TIMEOUT', None),
+            timeout=float(self._config.get('RPC_TIMEOUT')) if self._config.get('RPC_TIMEOUT') else None,
             context_data=self.context_data,
             worker_ctx_cls=self.worker_cls
         )

--- a/tests/test_flask_pooled_cluster_rpc_proxy.py
+++ b/tests/test_flask_pooled_cluster_rpc_proxy.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 from mock import Mock, patch, ANY, MagicMock
-from nameko.standalone.rpc import ClusterRpcProxy
+from nameko.standalone.rpc import ClusterRpcProxy, WorkerContext
 from flask import Flask, g
 from flask_nameko import FlaskPooledClusterRpcProxy
 from flask_nameko.connection_pool import ConnectionPool
@@ -86,7 +86,7 @@ def test_timeout_is_passed_through_to_cluster(flask_app):
     flask_app.config.update(dict(NAMEKO_RPC_TIMEOUT=10))
     with patch('flask_nameko.proxies.ClusterRpcProxy', spec_set=ClusterRpcProxy) as mock:
         FlaskPooledClusterRpcProxy(flask_app, connect_on_method_call=True)
-        mock.assert_called_with(ANY, timeout=10)
+        mock.assert_called_with(ANY, timeout=10, context_data=None, worker_ctx_cls=WorkerContext)
 
 def test_pool_recycle_is_passed_through_to_cluster(flask_app):
     flask_app.config.update(dict(NAMEKO_POOL_RECYCLE=3600))


### PR DESCRIPTION
I has done some useful changes that need for my project and it will be great if I can commit it to your repository.

- Support Python 3 (python 3.5 tested, python2 support shouldn't be broken)
- Availability to redefine context_data and worker_cls  for ClusterRpcProxy
- Add common exception for flask_nameko

Sorry for so many changes in one pull request.